### PR TITLE
Support axe-core^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "index.js"
   ],
   "dependencies": {
-    "axe-core": "^2.2.3"
+    "axe-core": "^2.2.3 || ^3.0.0"
   },
   "peerDependencies": {
     "testcafe": "*"


### PR DESCRIPTION
Version 3 contains [three breaking changing](https://github.com/dequelabs/axe-core/releases/tag/v3.0.0) (two rule-related and one API-related).

I've overwrote the dependency (https://stackoverflow.com/a/48524488) in my project and did not notice any issues.